### PR TITLE
データベース取り扱い補助のためのクラスを追加

### DIFF
--- a/TodoManager2.sln
+++ b/TodoManager2.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 16.0.30204.135
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoManager2", "TodoManager2\TodoManager2.csproj", "{E9945AC6-BFC6-48B0-9FA4-17E7B63F1D29}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TodoManager2Tests", "TodoManager2Tests\TodoManager2Tests.csproj", "{320BA970-35F3-45F8-8B0A-A6553E944741}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{E9945AC6-BFC6-48B0-9FA4-17E7B63F1D29}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E9945AC6-BFC6-48B0-9FA4-17E7B63F1D29}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E9945AC6-BFC6-48B0-9FA4-17E7B63F1D29}.Release|Any CPU.Build.0 = Release|Any CPU
+		{320BA970-35F3-45F8-8B0A-A6553E944741}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{320BA970-35F3-45F8-8B0A-A6553E944741}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{320BA970-35F3-45F8-8B0A-A6553E944741}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{320BA970-35F3-45F8-8B0A-A6553E944741}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/TodoManager2/TodoManager2.csproj
+++ b/TodoManager2/TodoManager2.csproj
@@ -14,6 +14,8 @@
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -37,6 +39,9 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Data.SQLite, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Core.1.0.113.1\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Core" />
@@ -87,6 +92,7 @@
       <Generator>ResXFileCodeGenerator</Generator>
       <LastGenOutput>Resources.Designer.cs</LastGenOutput>
     </EmbeddedResource>
+    <None Include="packages.config" />
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>
@@ -96,4 +102,11 @@
     <None Include="App.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets'))" />
+  </Target>
 </Project>

--- a/TodoManager2/TodoManager2.csproj
+++ b/TodoManager2/TodoManager2.csproj
@@ -69,6 +69,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="model\DatabaseHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -39,6 +39,30 @@ namespace TodoManager2.model {
             }
         }
 
+        /// <summary>
+        /// パラメーターに指定したコマンドを実行し、取得したSQLiteDataReaderから情報を読み込む
+        /// </summary>
+        /// <param name="commandText"></param>
+        /// <returns>内部で取得したSQLiteDataReaderの値をすべて詰め込んだオブジェクトを取得する</returns>
+        public List<Dictionary<string, object>> select(string commandText) {
+            using(var conn = new SQLiteConnection("Data Source=" + DatabaseName + ".sqlite")) {
+                SQLiteCommand command = new SQLiteCommand(commandText, conn);
+                conn.Open();
+
+                using (SQLiteDataReader sdr = command.ExecuteReader()) {
+                    var dictionarys = new List<Dictionary<string, object>>();
+                    while (sdr.Read()) {
+                        var dic = new Dictionary<string, object>();
+                        for(var i=0; i < sdr.FieldCount; i++) {
+                            dic[sdr.GetName(i)] = sdr.GetValue(i);
+                        }
+                        dictionarys.Add(dic);
+                    }
+                    return dictionarys;
+                }
+            }
+        }
+
         public void insert(string tableName, string[] columnNames, string[] values) {
             var commandText = "INSERT INTO " + tableName + " ";
 

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -3,16 +3,20 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Data.SQLite;
 
 namespace TodoManager2.model {
     public class DatabaseHelper {
 
+        public String DatabaseName { get; private set; } = "";
+
         public DatabaseHelper(string databaseName) {
+            DatabaseName = databaseName;
             create();
         }
 
         private void create() {
-
+            SQLiteConnection.CreateFile(DatabaseName + ".sqlite");
         }
     }
 }

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -27,6 +27,19 @@ namespace TodoManager2.model {
             executeNonQuery(createTableCommandText);
         }
 
+        /// <summary>
+        /// 指定したテーブルにNotNull制約のついた列を追加します
+        /// </summary>
+        /// <param name="tableName"></param>
+        /// <param name="columnName"></param>
+        /// <param name="type">列の型を指定します</param>
+        public void addNotNullColumn(string tableName, string columnName, string type) {
+            var addColumnCommandText =
+                "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + type + " NOT NULL;";
+
+            executeNonQuery(addColumnCommandText);
+        }
+
         private void executeNonQuery(string commandText) {
             using (var conn = new SQLiteConnection("Data Source=" + DatabaseName + ".sqlite")) {
                 conn.Open();

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TodoManager2.model {
+    public class DatabaseHelper {
+
+        public DatabaseHelper(string databaseName) {
+            create();
+        }
+
+        private void create() {
+
+        }
+    }
+}

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -38,5 +38,24 @@ namespace TodoManager2.model {
                 conn.Close();
             }
         }
+
+        public void insert(string tableName, string[] columnNames, string[] values) {
+            var commandText = "INSERT INTO " + tableName + " ";
+
+            var columnNamePart = "(";
+            new List<String>(columnNames).ForEach(tn => columnNamePart += tn + ", ");
+            columnNamePart = columnNamePart.Substring(0, columnNamePart.Length - 2);
+            columnNamePart += ")";
+
+            var valuePart = "VALUES (";
+            new List<String>(values).ForEach(v => valuePart += "'" + v + "', ");
+            valuePart = valuePart.Substring(0, valuePart.Length - 2);
+            valuePart += ");";
+
+            commandText += columnNamePart + " " + valuePart;
+
+            executeNonQuery(commandText);
+        }
+
     }
 }

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -22,7 +22,7 @@ namespace TodoManager2.model {
 
         private void createTable(String tableName) {
             var createTableCommandText = "CREATE TABLE IF NOT EXISTS " + tableName + " ( " +
-                                         "name TEXT NOT NULL" +
+                                         "id INTEGER PRIMARY KEY NOT NULL" +
                                          ");";
             executeNonQuery(createTableCommandText);
         }

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -46,19 +46,19 @@ namespace TodoManager2.model {
         /// <returns>内部で取得したSQLiteDataReaderの値をすべて詰め込んだオブジェクトを取得する</returns>
         public List<Dictionary<string, object>> select(string commandText) {
             using(var conn = new SQLiteConnection("Data Source=" + DatabaseName + ".sqlite")) {
-                SQLiteCommand command = new SQLiteCommand(commandText, conn);
-                conn.Open();
-
-                using (SQLiteDataReader sdr = command.ExecuteReader()) {
-                    var dictionarys = new List<Dictionary<string, object>>();
-                    while (sdr.Read()) {
-                        var dic = new Dictionary<string, object>();
-                        for(var i=0; i < sdr.FieldCount; i++) {
-                            dic[sdr.GetName(i)] = sdr.GetValue(i);
+                using(var command = new SQLiteCommand(commandText, conn)) {
+                    conn.Open();
+                    using (SQLiteDataReader sdr = command.ExecuteReader()) {
+                        var dictionarys = new List<Dictionary<string, object>>();
+                        while (sdr.Read()) {
+                            var dic = new Dictionary<string, object>();
+                            for(var i=0; i < sdr.FieldCount; i++) {
+                                dic[sdr.GetName(i)] = sdr.GetValue(i);
+                            }
+                            dictionarys.Add(dic);
                         }
-                        dictionarys.Add(dic);
+                        return dictionarys;
                     }
-                    return dictionarys;
                 }
             }
         }

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -13,10 +13,30 @@ namespace TodoManager2.model {
         public DatabaseHelper(string databaseName) {
             DatabaseName = databaseName;
             create();
+            createTable("todos");
         }
 
         private void create() {
             SQLiteConnection.CreateFile(DatabaseName + ".sqlite");
+        }
+
+        private void createTable(String tableName) {
+            var createTableCommandText = "CREATE TABLE IF NOT EXISTS " + tableName + " ( " +
+                                         "name TEXT NOT NULL" +
+                                         ");";
+            executeNonQuery(createTableCommandText);
+        }
+
+        private void executeNonQuery(string commandText) {
+            using (var conn = new SQLiteConnection("Data Source=" + DatabaseName + ".sqlite")) {
+                conn.Open();
+                using(var command = conn.CreateCommand()) {
+                    command.CommandText = commandText;
+                    command.ExecuteNonQuery();
+                }
+
+                conn.Close();
+            }
         }
     }
 }

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -72,7 +72,10 @@ namespace TodoManager2.model {
             columnNamePart += ")";
 
             var valuePart = "VALUES (";
-            new List<String>(values).ForEach(v => valuePart += "'" + v + "', ");
+            new List<String>(values).ForEach(v => {
+                if (long.TryParse(v, out long _)) valuePart += " " + v + ", ";
+                else valuePart += "'" + v + "', ";
+            });
             valuePart = valuePart.Substring(0, valuePart.Length - 2);
             valuePart += ");";
 

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Data.SQLite;
+using System.IO;
 
 namespace TodoManager2.model {
     public class DatabaseHelper {
@@ -17,7 +18,9 @@ namespace TodoManager2.model {
         }
 
         private void create() {
-            SQLiteConnection.CreateFile(DatabaseName + ".sqlite");
+            if(!File.Exists(DatabaseName + ".sqlite")) {
+                SQLiteConnection.CreateFile(DatabaseName + ".sqlite");
+            }
         }
 
         private void createTable(String tableName) {

--- a/TodoManager2/packages.config
+++ b/TodoManager2/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="System.Data.SQLite.Core" version="1.0.113.1" targetFramework="net472" />
+</packages>

--- a/TodoManager2Tests/Properties/AssemblyInfo.cs
+++ b/TodoManager2Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// アセンブリに関する一般情報は以下の属性セットを使用して制御されます。 
+// アセンブリに関連付けられている情報を変更するには、
+// これらの属性値を変更してください。
+[assembly: AssemblyTitle("TodoManager2Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TodoManager2Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// ComVisible を false に設定すると、その型はこのアセンブリ内で COM コンポーネントから
+// 参照不可能になります。COM からこのアセンブリ内の型にアクセスする場合は、 
+// その型の ComVisible 属性を true に設定してください。
+[assembly: ComVisible(false)]
+
+// このプロジェクトが COM に公開される場合、次の GUID が typelib の ID になります
+[assembly: Guid("320ba970-35f3-45f8-8b0a-a6553e944741")]
+
+// アセンブリのバージョン情報は次の 4 つの値で構成されています:
+//
+//      メジャー バージョン
+//      マイナー バージョン
+//      ビルド番号
+//      Revision
+//
+// すべての値を指定するか、次を使用してビルド番号とリビジョン番号を既定に設定できます
+// 既定値にすることができます:
+//[アセンブリ: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/TodoManager2Tests/TodoManager2Tests.csproj
+++ b/TodoManager2Tests/TodoManager2Tests.csproj
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{320BA970-35F3-45F8-8B0A-A6553E944741}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>TodoManager2Tests</RootNamespace>
+    <AssemblyName>TodoManager2Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
+    </Reference>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise />
+  </Choose>
+  <ItemGroup>
+    <Compile Include="model\DatabaseHelperTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TodoManager2\TodoManager2.csproj">
+      <Project>{E9945AC6-BFC6-48B0-9FA4-17E7B63F1D29}</Project>
+      <Name>TodoManager2</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>このプロジェクトは、このコンピューター上にない NuGet パッケージを参照しています。それらのパッケージをダウンロードするには、[NuGet パッケージの復元] を使用します。詳細については、http://go.microsoft.com/fwlink/?LinkID=322105 を参照してください。見つからないファイルは {0} です。</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets'))" />
+  </Target>
+  <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/TodoManager2Tests/TodoManager2Tests.csproj
+++ b/TodoManager2Tests/TodoManager2Tests.csproj
@@ -46,6 +46,9 @@
       <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
+    <Reference Include="System.Data.SQLite, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Data.SQLite.Core.1.0.113.1\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Choose>
     <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
@@ -94,8 +97,10 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.props'))" />
     <Error Condition="!Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets'))" />
+    <Error Condition="!Exists('..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets'))" />
   </Target>
   <Import Project="..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets" Condition="Exists('..\packages\MSTest.TestAdapter.2.1.1\build\net45\MSTest.TestAdapter.targets')" />
+  <Import Project="..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets" Condition="Exists('..\packages\System.Data.SQLite.Core.1.0.113.1\build\net46\System.Data.SQLite.Core.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/TodoManager2Tests/model/DatabaseHelperTests.cs
+++ b/TodoManager2Tests/model/DatabaseHelperTests.cs
@@ -22,22 +22,24 @@ namespace TodoManager2.model.Tests {
         public void insertTest() {
             var dbh = new DatabaseHelper(dbName);
 
-            string[] columnNames = { "name" };
+            string cName = "id";
+            string[] columnNames = { cName };
 
-            string[] values0 = { "valueTest1" };
-            string[] values1 = { "valueTest2" };
-            string[] values2 = { "valueTest3" };
+            string[] values0 = { "1" };
+            string[] values1 = { "2" };
+            string[] values2 = { "3" };
 
             dbh.insert("todos", columnNames, values0);
             dbh.insert("todos", columnNames, values1);
             dbh.insert("todos", columnNames, values2);
 
-            var vals = dbh.select("SELECT name FROM todos;");
+            var vals = dbh.select("SELECT " + cName + " FROM todos;");
 
             Assert.AreEqual(vals.Count, 3);
-            Assert.AreEqual(vals[0]["name"], "valueTest1");
-            Assert.AreEqual(vals[1]["name"], "valueTest2");
-            Assert.AreEqual(vals[2]["name"], "valueTest3");
+
+            Assert.AreEqual(vals[1][cName],(long)2);
+            Assert.AreEqual(vals[1][cName],(long)2);
+            Assert.AreEqual(vals[2][cName],(long)3);
         }
     }
 }

--- a/TodoManager2Tests/model/DatabaseHelperTests.cs
+++ b/TodoManager2Tests/model/DatabaseHelperTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.IO;
 
 namespace TodoManager2.model.Tests {
     [TestClass()]
@@ -33,13 +34,31 @@ namespace TodoManager2.model.Tests {
             dbh.insert("todos", columnNames, values1);
             dbh.insert("todos", columnNames, values2);
 
+
             var vals = dbh.select("SELECT " + cName + " FROM todos;");
 
             Assert.AreEqual(vals.Count, 3);
+            Assert.AreEqual(vals[0][cName], (long)1);
+            Assert.AreEqual(vals[1][cName], (long)2);
+            Assert.AreEqual(vals[2][cName], (long)3);
+        }
 
-            Assert.AreEqual(vals[1][cName],(long)2);
-            Assert.AreEqual(vals[1][cName],(long)2);
-            Assert.AreEqual(vals[2][cName],(long)3);
+        [TestMethod()]
+        public void addNotNullColumnTest() {
+            var dbh = new DatabaseHelper(dbName);
+
+            string defaultColumnName = "id";
+            string secondColumnName = "testColumn";
+
+            string[] columnNames =  { defaultColumnName, secondColumnName };
+            string[] value0 =       { "2",               "testText" };
+
+            dbh.addNotNullColumn("todos", secondColumnName, "TEXT");
+            dbh.insert("todos", columnNames, value0);
+            var vals = dbh.select("SELECT " + secondColumnName + " FROM todos;");
+
+            Assert.AreEqual(vals.Count, 1);
+            Assert.AreEqual(vals[0][secondColumnName], "testText");
         }
     }
 }

--- a/TodoManager2Tests/model/DatabaseHelperTests.cs
+++ b/TodoManager2Tests/model/DatabaseHelperTests.cs
@@ -14,7 +14,30 @@ namespace TodoManager2.model.Tests {
 
         [TestMethod()]
         public void DatabaseHelperTest() {
+            // 生成時にエラーが出ないかのテスト
             var dbh = new DatabaseHelper(dbName);
+        }
+
+        [TestMethod()]
+        public void insertTest() {
+            var dbh = new DatabaseHelper(dbName);
+
+            string[] columnNames = { "name" };
+
+            string[] values0 = { "valueTest1" };
+            string[] values1 = { "valueTest2" };
+            string[] values2 = { "valueTest3" };
+
+            dbh.insert("todos", columnNames, values0);
+            dbh.insert("todos", columnNames, values1);
+            dbh.insert("todos", columnNames, values2);
+
+            var vals = dbh.select("SELECT name FROM todos;");
+
+            Assert.AreEqual(vals.Count, 3);
+            Assert.AreEqual(vals[0]["name"], "valueTest1");
+            Assert.AreEqual(vals[1]["name"], "valueTest2");
+            Assert.AreEqual(vals[2]["name"], "valueTest3");
         }
     }
 }

--- a/TodoManager2Tests/model/DatabaseHelperTests.cs
+++ b/TodoManager2Tests/model/DatabaseHelperTests.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using System.IO;
 
 namespace TodoManager2.model.Tests {
     [TestClass()]
@@ -59,6 +58,11 @@ namespace TodoManager2.model.Tests {
 
             Assert.AreEqual(vals.Count, 1);
             Assert.AreEqual(vals[0][secondColumnName], "testText");
+        }
+
+        [TestCleanup()]
+        public void cleanup() {
+            System.IO.File.Delete(dbName + ".sqlite");
         }
     }
 }

--- a/TodoManager2Tests/model/DatabaseHelperTests.cs
+++ b/TodoManager2Tests/model/DatabaseHelperTests.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TodoManager2.model;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TodoManager2.model.Tests {
+    [TestClass()]
+    public class DatabaseHelperTests {
+
+        private string dbName = "testDatabase";
+
+        [TestMethod()]
+        public void DatabaseHelperTest() {
+            var dbh = new DatabaseHelper(dbName);
+        }
+    }
+}

--- a/TodoManager2Tests/packages.config
+++ b/TodoManager2Tests/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net472" />
+  <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net472" />
+</packages>

--- a/TodoManager2Tests/packages.config
+++ b/TodoManager2Tests/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net472" />
+  <package id="System.Data.SQLite.Core" version="1.0.113.1" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
- クラス追加 / データベース接続補助のためのクラスと、そのテストクラスを追加
- メイン, テストプロジェクトに System.Data.SQLite.Core の参照を追加
- 機能追加 / データベースファイルを作成するメソッドを追加
- 機能追加 / テーブルを新規作成するメソッド
- 機能追加 / 指定テーブルにデータを挿入するメソッドを追加
- 機能追加 / データベースからデータを取得するメソッドを追加
- テスト / データの挿入機能のテストを追加
- 仕様変更 / データベースを作成する際のデフォルトカラムの仕様を変更
- 機能拡張 / レコード追加時、文字列だけでなく数値も挿入できるように変更
- 機能修正 / select()内で接続をclose()できていなかったのを修正
- 機能追加 / テーブルに列を追加するためのメソッドを追加
- 仕様変更 / データベース作成処理を、ファイルが存在しない場合のみ実行するよう変更

close #1
