### PR TITLE
ビューモデルの作成

### DIFF
--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -33,6 +33,7 @@
                            FontSize="14"
                            />
                 <TextBox Name="titleInputTextBox"
+                         Text="{Binding CreatingTodo.Title, UpdateSourceTrigger=PropertyChanged}"
                          Margin="0,2,0,2"
                          Grid.Column="1"
                          FontSize="14"
@@ -51,6 +52,7 @@
                            FontSize="14"
                            />
                 <TextBox Name="textInputTextBox"
+                         Text="{Binding CreatingTodo.Text, UpdateSourceTrigger=PropertyChanged}"
                          Grid.Column="1"
                          Height="auto"
                          MaxHeight="60"
@@ -81,6 +83,7 @@
                            />
                 
                 <TextBox Name="workSpanInputTextBox"
+                         Text="{Binding CreatingTodo.WorkSpanMinutes, UpdateSourceTrigger=PropertyChanged}"
                          TextWrapping="Wrap"
                          AcceptsReturn="True"
                          Grid.Column="1"
@@ -94,6 +97,7 @@
                            />
 
                 <TextBox Name="priorityInputTextBox"
+                         Text="{Binding CreatingTodo.Priority, UpdateSourceTrigger=PropertyChanged}"
                          Grid.Column="3"
                          FontSize="14"
                          />
@@ -110,7 +114,7 @@
                         <ColumnDefinition/>
                     </Grid.ColumnDefinitions>
 
-                    <TextBox Text="0"
+                    <TextBox Text="{Binding CreatingTodo.DueDayNumber, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
                              Grid.Column="0"
                              FontSize="14"
                              />
@@ -135,6 +139,7 @@
                                />
 
                     <CheckBox Grid.Column="7"
+                              IsChecked="{Binding CreatingTodo.IsCompleted, UpdateSourceTrigger=PropertyChanged}" 
                               Margin="0,2,0,0"
                               FontSize="14"
                               />

--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -4,6 +4,7 @@
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:TodoManager2"
+        xmlns:i="clr-namespace:System.Windows.Interactivity;assembly=System.Windows.Interactivity"
         mc:Ignorable="d"
         Title="MainWindow" Height="600" Width="900">
 

--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -6,6 +6,11 @@
         xmlns:local="clr-namespace:TodoManager2"
         mc:Ignorable="d"
         Title="MainWindow" Height="600" Width="900">
+
+    <Window.DataContext>
+        <local:MainWindowViewModel/>
+    </Window.DataContext>
+
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="200"/>

--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -149,6 +149,7 @@
                         Grid.Column="8"
                         Margin="0,0,4,0"
                         FontSize="14"
+                        Command="{Binding AddTodoCommand}"
                         />
             </Grid>
 

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -10,9 +10,14 @@ using TodoManager2.model;
 namespace TodoManager2 {
     class MainWindowViewModel : BindableBase{
 
+        private Todo creatingTodo = new Todo();
         public Todo CreatingTodo {
-            get; set;
-        } = new Todo();
+            get => creatingTodo;
+            private set {
+                creatingTodo = value;
+                RaisePropertyChanged(nameof(CreatingTodo));
+            }
+        }
 
         private readonly string databaseName = "TodoDatabase";
         private DatabaseHelper databaseHelper;
@@ -61,6 +66,9 @@ namespace TodoManager2 {
                         todo.Priority = CreatingTodo.Priority;
                         todo.IsCompleted = CreatingTodo.IsCompleted;
                         todo.DueDayNumber = CreatingTodo.DueDayNumber;
+
+                        todoReaderWriter.add(todo);
+                        CreatingTodo = new Todo();
                     }
                 ));
             }

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TodoManager2 {
+    class MainWindowViewModel {
+    }
+}

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -14,6 +14,41 @@ namespace TodoManager2 {
             get; set;
         } = new Todo();
 
+        private readonly string databaseName = "TodoDatabase";
+        private DatabaseHelper databaseHelper;
+        private TodoReaderWriter todoReaderWriter;
+
+        public MainWindowViewModel() {
+            databaseHelper = new DatabaseHelper(databaseName);
+            todoReaderWriter = new TodoReaderWriter(databaseHelper);
+            buildDatabase();
+        }
+
+        private void buildDatabase() {
+            string textType = "TEXT";
+            string todoTableName = todoReaderWriter.todoTableName;
+            databaseHelper.createTable(todoTableName);
+            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.Title),textType);
+            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.Text),textType);
+            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.IsCompleted),textType);
+            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.Priority),textType);
+            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.CreationDateTime),textType);
+            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.DueDateTime),textType);
+            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.CompletionComment),textType);
+            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.CompletionDateTime),textType);
+            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.WorkSpan),textType);
+
+            string tagsTableName = todoReaderWriter.tagsTableName;
+            databaseHelper.createTable(tagsTableName);
+            databaseHelper.addNotNullColumn(tagsTableName, TagsTableColumnName.name.ToString(),textType);
+
+            string integerType = "INTEGER";
+            string tagMapsTableName = todoReaderWriter.tagMapsTableName;
+            databaseHelper.createTable(tagMapsTableName);
+            databaseHelper.addNotNullColumn(tagMapsTableName, TagMapsTableColumnName.tag_id.ToString(),integerType);
+            databaseHelper.addNotNullColumn(tagMapsTableName, TagMapsTableColumnName.todo_id.ToString(),integerType);
+        }
+
         private DelegateCommand addTodoCommand;
         public DelegateCommandBase AddTodoCommand {
             get {

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -4,8 +4,13 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Prism.Mvvm;
+using TodoManager2.model;
 
 namespace TodoManager2 {
     class MainWindowViewModel : BindableBase{
+
+        public Todo CreatingTodo {
+            get; set;
+        }
     }
 }

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -55,7 +55,7 @@ namespace TodoManager2 {
         }
 
         private DelegateCommand addTodoCommand;
-        public DelegateCommandBase AddTodoCommand {
+        public DelegateCommand AddTodoCommand {
             get {
                 return addTodoCommand ?? (addTodoCommand = new DelegateCommand(
                     () => {

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -69,8 +69,11 @@ namespace TodoManager2 {
 
                         todoReaderWriter.add(todo);
                         CreatingTodo = new Todo();
+                    },
+                    () => {
+                        return CreatingTodo.Title != "";
                     }
-                ));
+                ).ObservesProperty(() => CreatingTodo.Title));
             }
         }
     }

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -3,8 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Prism.Mvvm;
 
 namespace TodoManager2 {
-    class MainWindowViewModel {
+    class MainWindowViewModel : BindableBase{
     }
 }

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Prism.Mvvm;
+using Prism.Commands;
 using TodoManager2.model;
 
 namespace TodoManager2 {
@@ -11,6 +12,23 @@ namespace TodoManager2 {
 
         public Todo CreatingTodo {
             get; set;
+        } = new Todo();
+
+        private DelegateCommand addTodoCommand;
+        public DelegateCommandBase AddTodoCommand {
+            get {
+                return addTodoCommand ?? (addTodoCommand = new DelegateCommand(
+                    () => {
+                        Todo todo = new Todo(DateTime.Now, 0);
+                        todo.Title = CreatingTodo.Title;
+                        todo.Text = CreatingTodo.Text;
+                        todo.WorkSpan = CreatingTodo.WorkSpan;
+                        todo.Priority = CreatingTodo.Priority;
+                        todo.IsCompleted = CreatingTodo.IsCompleted;
+                        todo.DueDayNumber = CreatingTodo.DueDayNumber;
+                    }
+                ));
+            }
         }
     }
 }

--- a/TodoManager2/TodoManager2.csproj
+++ b/TodoManager2/TodoManager2.csproj
@@ -37,10 +37,16 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Prism, Version=7.2.0.1422, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\packages\Prism.Core.7.2.0.1422\lib\net45\Prism.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data" />
     <Reference Include="System.Data.SQLite, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Data.SQLite.Core.1.0.113.1\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />

--- a/TodoManager2/TodoManager2.csproj
+++ b/TodoManager2/TodoManager2.csproj
@@ -37,6 +37,9 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.Expression.Interactions, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Blend.Interactivity.Wpf.1.0.1340.0\lib\net\Microsoft.Expression.Interactions.dll</HintPath>
+    </Reference>
     <Reference Include="Prism, Version=7.2.0.1422, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
       <HintPath>..\packages\Prism.Core.7.2.0.1422\lib\net45\Prism.dll</HintPath>
     </Reference>
@@ -47,6 +50,9 @@
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Windows.Interactivity, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Blend.Interactivity.Wpf.1.0.1340.0\lib\net\System.Windows.Interactivity.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />

--- a/TodoManager2/TodoManager2.csproj
+++ b/TodoManager2/TodoManager2.csproj
@@ -74,6 +74,7 @@
     </Compile>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="MainWindowViewModel.cs" />
     <Compile Include="model\DatabaseHelper.cs" />
     <Compile Include="model\Todo.cs" />
     <Compile Include="model\TodoReaderWriter.cs" />

--- a/TodoManager2/model/DatabaseHelper.cs
+++ b/TodoManager2/model/DatabaseHelper.cs
@@ -30,6 +30,13 @@ namespace TodoManager2.model {
             executeNonQuery(createTableCommandText);
         }
 
+        public bool existColumn(String tableName, String columnName) {
+            var commandText = "PRAGMA table_info('" + tableName + "');";
+            var tableInfo = select(commandText);
+
+            return tableInfo.Any(dic => ((string)dic["name"] == columnName));
+        }
+
         /// <summary>
         /// 指定したテーブルにNotNull制約のついた列を追加します
         /// </summary>
@@ -37,6 +44,10 @@ namespace TodoManager2.model {
         /// <param name="columnName"></param>
         /// <param name="type">列の型を指定します</param>
         public void addNotNullColumn(string tableName, string columnName, string type) {
+            if (existColumn(tableName, columnName)) {
+                return;
+            }
+
             var addColumnCommandText =
                 "ALTER TABLE " + tableName + " ADD COLUMN " + columnName + " " + type + " NOT NULL;";
 

--- a/TodoManager2/model/Todo.cs
+++ b/TodoManager2/model/Todo.cs
@@ -4,9 +4,10 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using Prism.Mvvm;
 
 namespace TodoManager2.model {
-    public class Todo {
+    public class Todo : BindableBase{
 
         public Todo() {
 
@@ -29,7 +30,14 @@ namespace TodoManager2.model {
             }
         }
 
-        public string Title { get; set; }
+        private string title = "";
+        public string Title {
+            get => title;
+            set {
+                RaisePropertyChanged(nameof(Title));
+                title = value;
+            }
+        }
 
         private bool isCompleted = false;
         public bool IsCompleted {

--- a/TodoManager2/model/Todo.cs
+++ b/TodoManager2/model/Todo.cs
@@ -52,7 +52,24 @@ namespace TodoManager2.model {
 
         public DateTime CompletionDateTime { get; private set; } = new DateTime();
 
+        private int dueDateTime;
+        public int DueDayNumber {
+            get => dueDateTime;
+            set {
+                DueDateTime = DateTime.Today.AddDays(1 + value) ;
+                dueDateTime = value;
+            }
+        }
         public DateTime DueDateTime { get; set; } = new DateTime();
+
+        private int workSpanMinutes = 0;
+        public int WorkSpanMinutes {
+            get => workSpanMinutes;
+            set {
+                workSpanMinutes = value;
+                WorkSpan = new TimeSpan(0, workSpanMinutes, 0);
+            }
+        }
 
         public TimeSpan WorkSpan { get; set; } = new TimeSpan();
 

--- a/TodoManager2/model/TodoReaderWriter.cs
+++ b/TodoManager2/model/TodoReaderWriter.cs
@@ -21,8 +21,8 @@ namespace TodoManager2.model {
     public class TodoReaderWriter {
 
         private DatabaseHelper dbHelper;
-        private readonly string TABLE_NAME_TODOS = "todos";
 
+        public readonly string todoTableName = "todos";
         public readonly string tagsTableName = "tags";
         public readonly string tagMapsTableName = "tag_maps";
 
@@ -35,8 +35,8 @@ namespace TodoManager2.model {
 
             long newID = 0;
 
-            if(dbHelper.getRecordCount(TABLE_NAME_TODOS) > 0) {
-                newID = dbHelper.getMaxInColumn(TABLE_NAME_TODOS, "id") + 1;
+            if(dbHelper.getRecordCount(todoTableName) > 0) {
+                newID = dbHelper.getMaxInColumn(todoTableName, "id") + 1;
             }
 
             newID = Math.Max(newID, todo.ID);
@@ -67,11 +67,11 @@ namespace TodoManager2.model {
                 todo.WorkSpan.Ticks.ToString()
             };
 
-            dbHelper.insert(TABLE_NAME_TODOS, columnNames, values);
+            dbHelper.insert(todoTableName, columnNames, values);
         }
 
         public Todo getTodo(int id) {
-            var commandText = "SELECT * FROM " + TABLE_NAME_TODOS + " WHERE id = " + id;
+            var commandText = "SELECT * FROM " + todoTableName + " WHERE id = " + id;
             var dics = dbHelper.select(commandText);
 
             if (dics.Count == 0) {
@@ -83,7 +83,7 @@ namespace TodoManager2.model {
         }
 
         public List<Todo> getIncompleteTodos() {
-            var commandText = "SELECT * FROM " + TABLE_NAME_TODOS + " " 
+            var commandText = "SELECT * FROM " + todoTableName + " " 
                             + "WHERE " + nameof(Todo.IsCompleted) + " = 'False'";
 
             var dics = dbHelper.select(commandText);
@@ -104,7 +104,7 @@ namespace TodoManager2.model {
         /// <param name="maxDate">ここで指定した日時以前のTodoを取得します</param>
         /// <returns></returns>
         public List<Todo> getTodosWithin(DateTime minDate, DateTime maxDate) {
-            var commandText = "SELECT * FROM " + TABLE_NAME_TODOS + " "
+            var commandText = "SELECT * FROM " + todoTableName + " "
                             + "WHERE " + nameof(Todo.CreationDateTime).ToString() + " >= '" + minDate.ToString() + "' "
                             + "AND " + nameof(Todo.CreationDateTime).ToString() + " <= '" + maxDate.ToString() + "';";
 
@@ -150,7 +150,7 @@ namespace TodoManager2.model {
         /// </summary>
         /// <param name="updatedTodo"></param>
         public void update(Todo updatedTodo) {
-            var commandText = "UPDATE " + TABLE_NAME_TODOS + " "
+            var commandText = "UPDATE " + todoTableName + " "
                             + "SET " 
                             + nameof(Todo.Text) + " = '" + updatedTodo.Text + "', "
                             + nameof(Todo.Title) + " = '" + updatedTodo.Title + "', "
@@ -170,7 +170,7 @@ namespace TodoManager2.model {
         /// </summary>
         /// <param name="id"></param>
         public void delete(int id) {
-            dbHelper.executeNonQuery("DELETE FROM " + TABLE_NAME_TODOS + " WHERE id = " + id + ";");
+            dbHelper.executeNonQuery("DELETE FROM " + todoTableName + " WHERE id = " + id + ";");
         }
 
         /// <summary>
@@ -211,8 +211,8 @@ namespace TodoManager2.model {
                             +   "SELECT id FROM " + tagsTableName + " WHERE " + TagsTableColumnName.name + " = '" + tag + "')"
                             + ")" + " "
                             + "SELECT * FROM t1" + " "
-                            + "INNER JOIN " + TABLE_NAME_TODOS + " ON "
-                            + "t1." + todoIDColName + " = " + TABLE_NAME_TODOS + ".id;"; 
+                            + "INNER JOIN " + todoTableName + " ON "
+                            + "t1." + todoIDColName + " = " + todoTableName + ".id;"; 
 
             var dic = dbHelper.select(commandText);
             List<Todo> todos = new List<Todo>();

--- a/TodoManager2/packages.config
+++ b/TodoManager2/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Blend.Interactivity.Wpf" version="1.0.1340.0" targetFramework="net472" />
   <package id="Prism.Core" version="7.2.0.1422" targetFramework="net472" />
   <package id="System.Data.SQLite.Core" version="1.0.113.1" targetFramework="net472" />
   <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />

--- a/TodoManager2/packages.config
+++ b/TodoManager2/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Prism.Core" version="7.2.0.1422" targetFramework="net472" />
   <package id="System.Data.SQLite.Core" version="1.0.113.1" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>

--- a/TodoManager2Tests/model/DatabaseHelperTests.cs
+++ b/TodoManager2Tests/model/DatabaseHelperTests.cs
@@ -96,5 +96,14 @@ namespace TodoManager2.model.Tests {
             dbh.createTable("tagTable");
             Assert.AreEqual(dbh.getRecordCount("tagTable"), 0);
         }
+
+        [TestMethod()]
+        public void existColumnTest() {
+            var dbh = new DatabaseHelper(dbName);
+            dbh.createTable("testTable");
+            dbh.addNotNullColumn("testTable","testColumn","TEXT");
+            Assert.AreEqual(dbh.existColumn("testTable", "testColumn"), true);
+            Assert.AreEqual(dbh.existColumn("testTable", "testColumnA"), false);
+        }
     }
 }


### PR DESCRIPTION
- クラス追加 / MainWindow用のビューモデルとなるクラスを追加
- 開発補助のため、 NuGet から Prism.Core をインストールして参照に追加
- 開発補助のため、 NuGet から Blend.Interactivity.Wpf を追加
- 機能追加 / Todoに、Binding の際に変換処理を行うためのプロパティを追加
- MainWindow の一部項目と、MainWindowViewModel のプロパティをバインド
- 機能追加 / Todo追加ボタンに対するコマンドを追加
- 仕様変更 / 複数回同名の列を追加しようとしてもエラーが出ないよう変更
- 仕様変更 / Todoを格納するテーブルの名前を外から参照可能に変更
- 機能追加 / メインウィンドウのビューモデルにデータベースを作成するコードを追加
- 機能追加 / データベースに todo を登録する処理を追加
- ビューモデルで型を間違って宣言していたプロパティを修正
- 機能追加 / Todo のタイトルが未入力の状態では追加ボタンを押せないよう実装

データベースへ Todo の登録を行う機能を持つビューモデルを作成

close #11
