### PR TITLE
Todoのフィルタリングを行うビューの追加

### DIFF
--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -35,6 +35,34 @@
             <RowDefinition />
         </Grid.RowDefinitions>
 
+        <Grid Grid.Column="0"
+              Grid.RowSpan="2">
+            
+
+            <ListView ItemsSource="{Binding TagList}"
+                      Grid.Column="0"
+                      >
+                <ListView.View>
+                    <GridView>
+                        <GridViewColumn Header="tags"
+                                        Width="100"
+                                        DisplayMemberBinding="{Binding Content}"
+                                        />
+
+                        <GridViewColumn Header="check">
+                            <GridViewColumn.CellTemplate>
+                                <DataTemplate>
+                                    <CheckBox IsChecked="{Binding IsChecked}" />
+                                </DataTemplate>
+                            </GridViewColumn.CellTemplate>
+                        </GridViewColumn>
+
+                    </GridView>
+                </ListView.View>
+            </ListView>
+
+        </Grid>
+
         <StackPanel Grid.Column="1"
                     Grid.Row="0"
                     >

--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -163,6 +163,32 @@
                             <ComboBoxItem.Tag> 300 </ComboBoxItem.Tag>
                         </ComboBoxItem>
                     </ComboBox>
+
+                </Grid>
+            
+                <Grid Margin="0,3,0,3">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+                    <CheckBox Content="未完了を表示"
+                              Grid.Column="0"
+                              HorizontalAlignment="Center"
+                              IsChecked="{Binding TodoSearchOption.ShouldSelectIncompleteTodo}"
+                              />
+
+                    <Border Background="Black"
+                            Width="1"
+                            Grid.Column="1"
+                            HorizontalAlignment="Left"
+                            Margin="3,0,0,0"
+                            />
+
+                    <CheckBox Content="完了を表示"
+                              Grid.Column="1"
+                              HorizontalAlignment="Center"
+                              IsChecked="{Binding TodoSearchOption.ShouldSelectComplitionTodo}"
+                              />
                 </Grid>
 
                 <ListView ItemsSource="{Binding TagList}"

--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -129,6 +129,15 @@
                                />
                     <ComboBox Grid.Column="1">
 
+                        <i:Interaction.Triggers>
+                            <i:EventTrigger EventName="SelectionChanged">
+                                <i:InvokeCommandAction Command="{Binding ChangeResultCountLimit}"
+                                                       CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=ComboBox},
+                                                       Path=SelectedItem.Tag}"
+                                                       />
+                            </i:EventTrigger>
+                        </i:Interaction.Triggers>
+
                         <ComboBoxItem Content="100"
                                       IsSelected="True"
                                       HorizontalAlignment="Stretch">

--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -45,6 +45,52 @@
                         <ColumnDefinition/>
                     </Grid.ColumnDefinitions>
 
+                    <TextBlock Text="検索期間指定"
+                               Grid.Column="0"
+                               HorizontalAlignment="Center"
+                               />
+                    <ComboBox Grid.Column="1">
+
+                        <ComboBoxItem Content="今日のタスク"
+                                      HorizontalAlignment="Stretch">
+                            <ComboBoxItem.Tag> 1 </ComboBoxItem.Tag>
+                        </ComboBoxItem>
+
+                        <ComboBoxItem Content="３日前まで"
+                                      HorizontalAlignment="Stretch">
+                            <ComboBoxItem.Tag> 3 </ComboBoxItem.Tag>
+                        </ComboBoxItem>
+
+                        <ComboBoxItem Content="１週間前まで"
+                                      IsSelected="True"
+                                      HorizontalAlignment="Stretch">
+                            <ComboBoxItem.Tag> 7 </ComboBoxItem.Tag>
+                        </ComboBoxItem>
+
+                        <ComboBoxItem Content="１ヶ月前まで"
+                                      HorizontalAlignment="Stretch">
+                            <ComboBoxItem.Tag> 30 </ComboBoxItem.Tag>
+                        </ComboBoxItem>
+
+                        <ComboBoxItem Content="６ヶ月前まで"
+                                      HorizontalAlignment="Stretch">
+                            <ComboBoxItem.Tag> 180 </ComboBoxItem.Tag>
+                        </ComboBoxItem>
+
+                        <ComboBoxItem Content="期間無指定"
+                                      HorizontalAlignment="Stretch">
+                            <ComboBoxItem.Tag> -1 </ComboBoxItem.Tag>
+                        </ComboBoxItem>
+
+                    </ComboBox>
+                </Grid>
+
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+
                     <TextBlock Text="タグ検索方式"
                                Margin="0,2,0,0"
                                HorizontalAlignment="Center"

--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -51,35 +51,44 @@
                                />
                     <ComboBox Grid.Column="1">
 
+                        <i:Interaction.Triggers>
+                            <i:EventTrigger EventName="SelectionChanged">
+                                <i:InvokeCommandAction Command="{Binding ChangeSearchStartPointCommand}"
+                                                       CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=ComboBox},
+                                                       Path=SelectedItem.Tag}"
+                                                       />
+                            </i:EventTrigger>
+                        </i:Interaction.Triggers>
+
                         <ComboBoxItem Content="今日のタスク"
                                       HorizontalAlignment="Stretch">
-                            <ComboBoxItem.Tag> 1 </ComboBoxItem.Tag>
+                            <ComboBoxItem.Tag> -1 </ComboBoxItem.Tag>
                         </ComboBoxItem>
 
                         <ComboBoxItem Content="３日前まで"
                                       HorizontalAlignment="Stretch">
-                            <ComboBoxItem.Tag> 3 </ComboBoxItem.Tag>
+                            <ComboBoxItem.Tag> -3 </ComboBoxItem.Tag>
                         </ComboBoxItem>
 
                         <ComboBoxItem Content="１週間前まで"
                                       IsSelected="True"
                                       HorizontalAlignment="Stretch">
-                            <ComboBoxItem.Tag> 7 </ComboBoxItem.Tag>
+                            <ComboBoxItem.Tag> -7 </ComboBoxItem.Tag>
                         </ComboBoxItem>
 
                         <ComboBoxItem Content="１ヶ月前まで"
                                       HorizontalAlignment="Stretch">
-                            <ComboBoxItem.Tag> 30 </ComboBoxItem.Tag>
+                            <ComboBoxItem.Tag> -30 </ComboBoxItem.Tag>
                         </ComboBoxItem>
 
                         <ComboBoxItem Content="６ヶ月前まで"
                                       HorizontalAlignment="Stretch">
-                            <ComboBoxItem.Tag> 180 </ComboBoxItem.Tag>
+                            <ComboBoxItem.Tag> -180 </ComboBoxItem.Tag>
                         </ComboBoxItem>
 
                         <ComboBoxItem Content="期間無指定"
                                       HorizontalAlignment="Stretch">
-                            <ComboBoxItem.Tag> -1 </ComboBoxItem.Tag>
+                            <ComboBoxItem.Tag> -100000 </ComboBoxItem.Tag>
                         </ComboBoxItem>
 
                     </ComboBox>

--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -37,30 +37,62 @@
 
         <Grid Grid.Column="0"
               Grid.RowSpan="2">
-            
+            <StackPanel>
 
-            <ListView ItemsSource="{Binding TagList}"
-                      Grid.Column="0"
-                      >
-                <ListView.View>
-                    <GridView>
-                        <GridViewColumn Header="tags"
-                                        Width="100"
-                                        DisplayMemberBinding="{Binding Content}"
-                                        />
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
 
-                        <GridViewColumn Header="check">
-                            <GridViewColumn.CellTemplate>
-                                <DataTemplate>
-                                    <CheckBox IsChecked="{Binding IsChecked}" />
-                                </DataTemplate>
-                            </GridViewColumn.CellTemplate>
-                        </GridViewColumn>
+                    <TextBlock Text="タグ検索方式"
+                               Margin="0,2,0,0"
+                               HorizontalAlignment="Center"
+                               Grid.Column="0"
+                               />
+                    <ComboBox Grid.Column="1" >
 
-                    </GridView>
-                </ListView.View>
-            </ListView>
+                        <i:Interaction.Triggers>
+                            <i:EventTrigger EventName="SelectionChanged">
+                                <i:InvokeCommandAction Command="{Binding ChangeTagSearchTypeCommand}"
+                                                       CommandParameter="{Binding RelativeSource={RelativeSource AncestorType=ComboBox},
+                                                       Path=SelectedItem.Content}"
+                                                       />
+                            </i:EventTrigger>
+                        </i:Interaction.Triggers>
+                        <ComboBoxItem Content="AND"
+                                      HorizontalAlignment="Stretch">
+                        </ComboBoxItem>
 
+                        <ComboBoxItem Content="OR"
+                                      IsSelected="True"
+                                      HorizontalAlignment="Stretch">
+                        </ComboBoxItem>
+                    </ComboBox>
+                </Grid>
+                <ListView ItemsSource="{Binding TagList}"
+                          Grid.Column="0"
+                          >
+                    <ListView.View>
+                        <GridView>
+                            <GridViewColumn Header="tags"
+                                            Width="100"
+                                            DisplayMemberBinding="{Binding Content}"
+                                            />
+
+                            <GridViewColumn Header="check">
+                                <GridViewColumn.CellTemplate>
+                                    <DataTemplate>
+                                        <CheckBox IsChecked="{Binding IsChecked}" />
+                                    </DataTemplate>
+                                </GridViewColumn.CellTemplate>
+                            </GridViewColumn>
+
+                        </GridView>
+                    </ListView.View>
+                </ListView>
+
+            </StackPanel>
         </Grid>
 
         <StackPanel Grid.Column="1"

--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -132,9 +132,18 @@
                         <ComboBoxItem Content="100"
                                       IsSelected="True"
                                       HorizontalAlignment="Stretch">
-                            <ComboBoxItem.Tag> 100 </ComboBoxItem.Tag>
+                            <ComboBoxItem.Tag>100</ComboBoxItem.Tag>
                         </ComboBoxItem>
 
+                        <ComboBoxItem Content="200"
+                                      HorizontalAlignment="Stretch">
+                            <ComboBoxItem.Tag> 200 </ComboBoxItem.Tag>
+                        </ComboBoxItem>
+
+                        <ComboBoxItem Content="300"
+                                      HorizontalAlignment="Stretch">
+                            <ComboBoxItem.Tag> 300 </ComboBoxItem.Tag>
+                        </ComboBoxItem>
                     </ComboBox>
                 </Grid>
 

--- a/TodoManager2/MainWindow.xaml
+++ b/TodoManager2/MainWindow.xaml
@@ -116,6 +116,28 @@
                         </ComboBoxItem>
                     </ComboBox>
                 </Grid>
+
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition/>
+                        <ColumnDefinition/>
+                    </Grid.ColumnDefinitions>
+
+                    <TextBlock Text="検索数上限"
+                               Grid.Column="0"
+                               HorizontalAlignment="Center"
+                               />
+                    <ComboBox Grid.Column="1">
+
+                        <ComboBoxItem Content="100"
+                                      IsSelected="True"
+                                      HorizontalAlignment="Stretch">
+                            <ComboBoxItem.Tag> 100 </ComboBoxItem.Tag>
+                        </ComboBoxItem>
+
+                    </ComboBox>
+                </Grid>
+
                 <ListView ItemsSource="{Binding TagList}"
                           Grid.Column="0"
                           >

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -61,7 +61,7 @@ namespace TodoManager2 {
             databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.DueDateTime),textType);
             databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.CompletionComment),textType);
             databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.CompletionDateTime),textType);
-            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.WorkSpan),textType);
+            databaseHelper.addNotNullColumn(todoTableName, nameof(Todo.WorkSpan),"INTEGER");
 
             string tagsTableName = todoReaderWriter.tagsTableName;
             databaseHelper.createTable(tagsTableName);

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -136,5 +136,16 @@ namespace TodoManager2 {
                 ));
             }
         }
+
+        private DelegateCommand<object> changeSearchStartPointCommand;
+        public DelegateCommand<object> ChangeSearchStartPointCommand {
+            get {
+                return changeSearchStartPointCommand ?? (changeSearchStartPointCommand = new DelegateCommand<object>(
+                    (object param) => {
+                        todoSearchOption.SearchStartPoint = DateTime.Now.AddDays(double.Parse((string)param));
+                    }
+                ));
+            }
+        }
     }
 }

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -111,7 +111,10 @@ namespace TodoManager2 {
         public DelegateCommand ReloadTodoListCommand {
             get {
                 return reloadTodoListCommand ?? (reloadTodoListCommand = new DelegateCommand(
-                    () => TodoList = todoReaderWriter.getTodosWithin(DateTime.MinValue, DateTime.Now)));
+                    () => {
+                        TodoList = todoReaderWriter.getTodo(todoSearchOption);
+                    }
+                ));
             }
         }
 
@@ -121,6 +124,7 @@ namespace TodoManager2 {
                 return changeTagSearchTypeCommand ?? (changeTagSearchTypeCommand = new DelegateCommand<object>(
                     (object param) => {
                         todoSearchOption.TagSearchTypeIsOR = (String.Compare((string)param,"OR") == 0) ? true : false;
+                        reloadTodoListCommand.Execute();
                     }
                 ));
             }
@@ -132,6 +136,7 @@ namespace TodoManager2 {
                 return changeResultCountLimit ?? (changeResultCountLimit = new DelegateCommand<object>(
                     (object param) => {
                         todoSearchOption.ResultCountLimit = long.Parse((string)param);
+                        reloadTodoListCommand.Execute();
                     }
                 ));
             }
@@ -143,6 +148,7 @@ namespace TodoManager2 {
                 return changeSearchStartPointCommand ?? (changeSearchStartPointCommand = new DelegateCommand<object>(
                     (object param) => {
                         todoSearchOption.SearchStartPoint = DateTime.Now.AddDays(double.Parse((string)param));
+                        reloadTodoListCommand.Execute();
                     }
                 ));
             }

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -40,6 +40,7 @@ namespace TodoManager2 {
         private readonly string databaseName = "TodoDatabase";
         private DatabaseHelper databaseHelper;
         private TodoReaderWriter todoReaderWriter;
+        private TodoSearchOption todoSearchOption = new TodoSearchOption();
 
         public MainWindowViewModel() {
             databaseHelper = new DatabaseHelper(databaseName);
@@ -111,6 +112,17 @@ namespace TodoManager2 {
             get {
                 return reloadTodoListCommand ?? (reloadTodoListCommand = new DelegateCommand(
                     () => TodoList = todoReaderWriter.getTodosWithin(DateTime.MinValue, DateTime.Now)));
+            }
+        }
+
+        private DelegateCommand<object> changeTagSearchTypeCommand;
+        public DelegateCommand<object> ChangeTagSearchTypeCommand {
+            get {
+                return changeTagSearchTypeCommand ?? (changeTagSearchTypeCommand = new DelegateCommand<object>(
+                    (object param) => {
+                        todoSearchOption.TagSearchTypeIsOR = (String.Compare((string)param,"OR") == 0) ? true : false;
+                    }
+                ));
             }
         }
     }

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -125,5 +125,16 @@ namespace TodoManager2 {
                 ));
             }
         }
+
+        private DelegateCommand<object> changeResultCountLimit;
+        public DelegateCommand<object> ChangeResultCountLimit {
+            get {
+                return changeResultCountLimit ?? (changeResultCountLimit = new DelegateCommand<object>(
+                    (object param) => {
+                        todoSearchOption.ResultCountLimit = long.Parse((string)param);
+                    }
+                ));
+            }
+        }
     }
 }

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -28,6 +28,15 @@ namespace TodoManager2 {
             }
         }
 
+        private List<Tag> tagList = new List<Tag>();
+        public List<Tag> TagList {
+            get => tagList;
+            set {
+                tagList = value;
+                RaisePropertyChanged();
+            }
+        }
+
         private readonly string databaseName = "TodoDatabase";
         private DatabaseHelper databaseHelper;
         private TodoReaderWriter todoReaderWriter;

--- a/TodoManager2/MainWindowViewModel.cs
+++ b/TodoManager2/MainWindowViewModel.cs
@@ -42,6 +42,11 @@ namespace TodoManager2 {
         private TodoReaderWriter todoReaderWriter;
         private TodoSearchOption todoSearchOption = new TodoSearchOption();
 
+        public TodoSearchOption TodoSearchOption {
+            get => todoSearchOption;
+            private set => todoSearchOption = value;
+        }
+
         public MainWindowViewModel() {
             databaseHelper = new DatabaseHelper(databaseName);
             todoReaderWriter = new TodoReaderWriter(databaseHelper);

--- a/TodoManager2/TodoManager2.csproj
+++ b/TodoManager2/TodoManager2.csproj
@@ -94,6 +94,7 @@
     <Compile Include="model\Tag.cs" />
     <Compile Include="model\Todo.cs" />
     <Compile Include="model\TodoReaderWriter.cs" />
+    <Compile Include="model\TodoSearchOption.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/TodoManager2/TodoManager2.csproj
+++ b/TodoManager2/TodoManager2.csproj
@@ -91,6 +91,7 @@
   <ItemGroup>
     <Compile Include="MainWindowViewModel.cs" />
     <Compile Include="model\DatabaseHelper.cs" />
+    <Compile Include="model\Tag.cs" />
     <Compile Include="model\Todo.cs" />
     <Compile Include="model\TodoReaderWriter.cs" />
     <Compile Include="Properties\AssemblyInfo.cs">

--- a/TodoManager2/model/Tag.cs
+++ b/TodoManager2/model/Tag.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Prism.Mvvm;
+
+namespace TodoManager2.model {
+    class Tag : BindableBase{
+
+        private string content;
+        public string Content {
+            get => content;
+            set {
+                content = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private int id;
+        public int ID {
+            get => id;
+            set {
+                id = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private bool isChecked;
+        public bool IsChecked {
+            get => isChecked;
+            set {
+                isChecked = value;
+                RaisePropertyChanged();
+            }
+        }
+    }
+}

--- a/TodoManager2/model/Tag.cs
+++ b/TodoManager2/model/Tag.cs
@@ -6,7 +6,11 @@ using System.Threading.Tasks;
 using Prism.Mvvm;
 
 namespace TodoManager2.model {
-    class Tag : BindableBase{
+    public class Tag : BindableBase{
+
+        public Tag(string tagContent) {
+            content = tagContent;
+        }
 
         private string content;
         public string Content {

--- a/TodoManager2/model/TodoReaderWriter.cs
+++ b/TodoManager2/model/TodoReaderWriter.cs
@@ -254,5 +254,67 @@ namespace TodoManager2.model {
             var commandText = "DELETE FROM " + tagsTableName + " WHERE " + TagsTableColumnName.name + " = '" + tag + "';";
             dbHelper.executeNonQuery(commandText);
         }
+
+        public List<Todo> getTodo(TodoSearchOption searchOption) {
+            string tagIDColName = TagMapsTableColumnName.tag_id.ToString();
+            string todoIDColName = TagMapsTableColumnName.todo_id.ToString();
+
+            var narrowDownTodoTableSQL = "SELECT * FROM " + todoTableName + " WHERE ";
+
+            // 作成日時によってフィルタリング
+            if(searchOption.SearchStartPoint != DateTime.MinValue) {
+                narrowDownTodoTableSQL += nameof(Todo.CreationDateTime) + " > '" + searchOption.SearchStartPoint + "' AND ";
+            }
+
+            // 完了、未完了の Todo をフィルタリング
+            if(searchOption.ShouldSelectComplitionTodo || searchOption.ShouldSelectIncompleteTodo) {
+                if (searchOption.ShouldSelectComplitionTodo) {
+                    narrowDownTodoTableSQL += nameof(Todo.IsCompleted) + " = 'True'";
+                }
+
+                if (searchOption.ShouldSelectIncompleteTodo) {
+                    if (searchOption.ShouldSelectComplitionTodo) {
+                        narrowDownTodoTableSQL += " OR ";
+                    }
+                    narrowDownTodoTableSQL += nameof(Todo.IsCompleted) + " = 'False'";
+                }
+            }
+
+            var commandText = "";
+
+            if(searchOption.Tags.Count > 0) {
+                var tags = "";
+                searchOption.Tags.ForEach(t => tags += "'" + t.Content + "', ");
+                tags = tags.Substring(0, tags.Length - 2);
+
+                string groupBy = "GROUP BY " + todoIDColName;
+                if (!searchOption.TagSearchTypeIsOR) {
+                    groupBy += " HAVING COUNT(*) = " + searchOption.Tags.Count + " ";
+                }
+
+                commandText = "WITH t1 AS"
+                                + "(" + " "
+                                + "SELECT " + tagIDColName + ", " + todoIDColName + ", COUNT(*)" + " "
+                                + "FROM " + tagMapsTableName + " "
+                                + "WHERE " + tagIDColName + " IN ("
+                                + "SELECT id FROM " + tagsTableName + " WHERE " + TagsTableColumnName.name + " IN (" + tags + ") "
+                                + ") " + groupBy
+                                + "), t2 AS (" + narrowDownTodoTableSQL + ")"
+                                + "SELECT * FROM t1" + " "
+                                + "INNER JOIN t2 ON "
+                                + "t1." + todoIDColName + " = t2.id "
+                                + "ORDER BY " + nameof(Todo.CreationDateTime) + " "
+                                + "LIMIT " + searchOption.ResultCountLimit + ";";
+            }
+            else {
+                // tag による絞り込みが不要である場合、todoTable の絞り込みのためのsqlをそのままコマンドとして採用する
+                commandText = narrowDownTodoTableSQL + ";";
+            }
+
+            var dic = dbHelper.select(commandText);
+            List<Todo> todos = new List<Todo>();
+            dic.ForEach(d => { todos.Add(toTodo(d)); });
+            return todos;
+        }
     }
 }

--- a/TodoManager2/model/TodoReaderWriter.cs
+++ b/TodoManager2/model/TodoReaderWriter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 /// <summary>
 /// このクラスでは Todo オブジェクトをデータベースに書き込んだり、List として取り出したりする機能を提供します。
@@ -199,16 +200,20 @@ namespace TodoManager2.model {
             dbHelper.insert(tagMapTableName, columnNames, values);
         }
 
-        public List<Todo> getTodoFromTag(string tag) {
+        public List<Todo> getTodoFromTag(List<Tag> tagList) {
             string tagIDColName = TagMapsTableColumnName.tag_id.ToString();
             string todoIDColName = TagMapsTableColumnName.todo_id.ToString();
+
+            var tags = "";
+            tagList.ForEach(t => tags += "'" + t.Content + "', " );
+            tags = tags.Substring(0, tags.Length - 2);
 
             var commandText = "WITH t1 AS"
                             + "(" + " " 
                             +   "SELECT " + tagIDColName + ", " + todoIDColName + " "
                             +   "FROM " + tagMapsTableName + " "
-                            +   "WHERE " + tagIDColName + " = ("
-                            +   "SELECT id FROM " + tagsTableName + " WHERE " + TagsTableColumnName.name + " = '" + tag + "')"
+                            +   "WHERE " + tagIDColName + " IN ("
+                            +   "SELECT id FROM " + tagsTableName + " WHERE " + TagsTableColumnName.name + " IN (" + tags + "))"
                             + ")" + " "
                             + "SELECT * FROM t1" + " "
                             + "INNER JOIN " + todoTableName + " ON "

--- a/TodoManager2/model/TodoReaderWriter.cs
+++ b/TodoManager2/model/TodoReaderWriter.cs
@@ -268,6 +268,8 @@ namespace TodoManager2.model {
 
             // 完了、未完了の Todo をフィルタリング
             if(searchOption.ShouldSelectComplitionTodo || searchOption.ShouldSelectIncompleteTodo) {
+                narrowDownTodoTableSQL += " (";
+
                 if (searchOption.ShouldSelectComplitionTodo) {
                     narrowDownTodoTableSQL += nameof(Todo.IsCompleted) + " = 'True'";
                 }
@@ -278,6 +280,8 @@ namespace TodoManager2.model {
                     }
                     narrowDownTodoTableSQL += nameof(Todo.IsCompleted) + " = 'False'";
                 }
+
+                narrowDownTodoTableSQL += ")";
             }
 
             var commandText = "";

--- a/TodoManager2/model/TodoReaderWriter.cs
+++ b/TodoManager2/model/TodoReaderWriter.cs
@@ -136,7 +136,7 @@ namespace TodoManager2.model {
             todo.Title = (string)todoDictionary[nameof(Todo.Title)];
             todo.Priority = (string)todoDictionary[nameof(Todo.Priority)];
             todo.CompletionComment = (string)todoDictionary[nameof(Todo.CompletionComment)];
-            todo.WorkSpan = new TimeSpan(long.Parse((string)todoDictionary[nameof(Todo.WorkSpan)]));
+            todo.WorkSpan = new TimeSpan((long)todoDictionary[nameof(Todo.WorkSpan)]);
 
             if(completionDate.CompareTo(new DateTime()) != 0) {
                 todo.IsCompleted = true;

--- a/TodoManager2/model/TodoSearchOption.cs
+++ b/TodoManager2/model/TodoSearchOption.cs
@@ -1,0 +1,84 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Prism.Mvvm;
+
+namespace TodoManager2.model {
+    public class TodoSearchOption : BindableBase{
+
+        private List<Tag> tags = new List<Tag>();
+        public List<Tag> Tags {
+            get => tags;
+            set {
+                tags = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private Boolean tagSearchTypeisOR = false;
+
+        /// <summary>
+        /// タグ検索の方式が OR 検索であるかどうかを示します。
+        /// false に指定した場合、And 検索に切り替わります。
+        /// </summary>
+        public Boolean TagSearchTypeIsOR {
+            get => tagSearchTypeisOR;
+            set {
+                tagSearchTypeisOR = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private DateTime searchStartPoint = DateTime.MinValue;
+
+        /// <summary>
+        /// このプロパティに指定した日時以降に作祭されたTodoを検索するよう指定します。
+        /// デフォルトでは全期間を検索結果に含めるようになっています。
+        /// </summary>
+        public DateTime SearchStartPoint {
+            get => searchStartPoint;
+            set {
+                searchStartPoint = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private Boolean shouldSelectComplitionTodo = true;
+
+        /// <summary>
+        /// 完了済みのTodoを検索結果に含めるかどうかを指定します。デフォルトは true です
+        /// </summary>
+        public Boolean ShouldSelectComplitionTodo {
+            get => shouldSelectComplitionTodo;
+            set {
+                shouldSelectComplitionTodo = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private Boolean shouldSelectIncompleteTodo = true;
+
+        /// <summary>
+        /// 未完了のTodoを検索結果に含めるかどうかを指定します。デフォルトは　true です
+        /// </summary>
+        public Boolean ShouldSelectIncompleteTodo {
+            get => shouldSelectIncompleteTodo;
+            set {
+                shouldSelectIncompleteTodo = value;
+                RaisePropertyChanged();
+            }
+        }
+
+        private long resultCountLimit = 100;
+        public long ResultCountLimit {
+            get => resultCountLimit;
+            set {
+                resultCountLimit = value;
+                RaisePropertyChanged();
+            }
+        }
+
+    }
+}

--- a/TodoManager2Tests/TodoManager2Tests.csproj
+++ b/TodoManager2Tests/TodoManager2Tests.csproj
@@ -45,9 +45,15 @@
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\MSTest.TestFramework.2.1.1\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
+    <Reference Include="Prism, Version=7.2.0.1422, Culture=neutral, PublicKeyToken=40ee6c3a2184dc59, processorArchitecture=MSIL">
+      <HintPath>..\packages\Prism.Core.7.2.0.1422\lib\net45\Prism.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Data.SQLite, Version=1.0.113.0, Culture=neutral, PublicKeyToken=db937bc2d44ff139, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Data.SQLite.Core.1.0.113.1\lib\net46\System.Data.SQLite.dll</HintPath>
+    </Reference>
+    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/TodoManager2Tests/model/TodoReaderWriterTests.cs
+++ b/TodoManager2Tests/model/TodoReaderWriterTests.cs
@@ -196,8 +196,13 @@ namespace TodoManager2.model.Tests {
             todoReaderWriter.add(testTodos[0]);
             todoReaderWriter.add(testTodos[1]);
 
-            Assert.AreEqual(todoReaderWriter.getTodoFromTag("testTag1").Count, 1);
-            Assert.AreEqual(todoReaderWriter.getTodoFromTag("testTag2").Count, 2);
+            var tags1 = new List<Tag>(new Tag[] { new Tag("testTag1") });
+            var tags2 = new List<Tag>(new Tag[] { new Tag("testTag2") });
+            var allTags = new List<Tag>(new Tag[] { new Tag("testTag1"),new Tag("testTag2") });
+
+            Assert.AreEqual(todoReaderWriter.getTodoFromTag(tags1).Count, 1);
+            Assert.AreEqual(todoReaderWriter.getTodoFromTag(tags2).Count, 2);
+            Assert.AreEqual(todoReaderWriter.getTodoFromTag(allTags).Count, 3);
 
         }
 
@@ -232,11 +237,14 @@ namespace TodoManager2.model.Tests {
             todoReaderWriter.add(todos[0]);
             todoReaderWriter.add(todos[1]);
 
-            Assert.AreEqual(todoReaderWriter.getTodoFromTag("tag0").Count, 1);
-            Assert.AreEqual(todoReaderWriter.getTodoFromTag("tag1").Count, 2);
-            Assert.AreEqual(todoReaderWriter.getTodoFromTag("tag0")[0].Title, "todo0title");
-            Assert.AreEqual(todoReaderWriter.getTodoFromTag("tag1")[0].Title, "todo0title");
-            Assert.AreEqual(todoReaderWriter.getTodoFromTag("tag1")[1].Title, "todo1title");
+            List<Tag> tags0 = new List<Tag>(new Tag[] { new Tag("tag0") });
+            List<Tag> tags1 = new List<Tag>(new Tag[] { new Tag("tag1") });
+
+            Assert.AreEqual(todoReaderWriter.getTodoFromTag(tags0).Count, 1);
+            Assert.AreEqual(todoReaderWriter.getTodoFromTag(tags1).Count, 2);
+            Assert.AreEqual(todoReaderWriter.getTodoFromTag(tags0)[0].Title, "todo0title");
+            Assert.AreEqual(todoReaderWriter.getTodoFromTag(tags1)[0].Title, "todo0title");
+            Assert.AreEqual(todoReaderWriter.getTodoFromTag(tags1)[1].Title, "todo1title");
         }
 
         [TestMethod()]

--- a/TodoManager2Tests/packages.config
+++ b/TodoManager2Tests/packages.config
@@ -2,5 +2,7 @@
 <packages>
   <package id="MSTest.TestAdapter" version="2.1.1" targetFramework="net472" />
   <package id="MSTest.TestFramework" version="2.1.1" targetFramework="net472" />
+  <package id="Prism.Core" version="7.2.0.1422" targetFramework="net472" />
   <package id="System.Data.SQLite.Core" version="1.0.113.1" targetFramework="net472" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net472" />
 </packages>


### PR DESCRIPTION
- クラス追加 / タグによるフィルタリングの際、必要な情報を格納するクラスを追加
- バグ修正 / WorkSpan のコンストラクタ引数に渡す値のキャストが失敗する
- 機能拡張 / tag から Todo を検索して取得する機能を拡張
- バグ修正 / 初回DB生成時、列の型を間違って生成していたのを修正
- 機能追加 / Todo の検索条件をまとめたクラスを作成
- 機能追加 / オプションを指定して Todo を検索する機能を追加
- 機能追加 / タグ検索のオプション OR,AND検索 を切り替えるコマンドとUIを追加
- UI変更 / 検索する期間を指定するためのコンボボックスを追加
- 機能追加 / 検索結果の上限数を指定するためのコンボボックスを追加
- UI変更 / 検索数上限を選ぶコンボボックスに項目を追加
- 機能追加 / 検索上限数を指定するコマンドを追加し、UIとバインド
- 機能追加 / UIから検索する期間を指定するコマンドを追加、UIとバインド
- バグ修正 / SQLの条件の優先順位が意図通りでなかったので括弧を足して修正
- 仕様変更 / 検索条件を変更した場合、毎回 Todo のリストを取得して更新する仕様に変更
- 機能追加 / 完了、未完了タスクの表示をUIから切り替えできるよう実装

close #16
